### PR TITLE
Remove Drupal X-Generator header

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -377,6 +377,7 @@ sub vcl_deliver {
   unset resp.http.X-Varnish;
   unset resp.http.Via;
   unset resp.http.Link;
+  unset resp.http.X-Generator;
 
   return (deliver);
 }


### PR DESCRIPTION
By default drupal sends the X-Generator header:

```X-Generator: "Drupal 7 (http://drupal.org)"```

Which you want to remove for spam bots etc.