### PR TITLE
Fix redirects

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -395,14 +395,14 @@ sub vcl_synth {
   if (resp.status == 720) {
     # We use this special error status 720 to force redirects with 301 (permanent) redirects
     # To use this, call the following from anywhere in vcl_recv: return (synth(720, "http://host/new.html"));
-    set resp.status = 301;
     set resp.http.Location = resp.reason;
+    set resp.status = 301;
     return (deliver);
   } elseif (resp.status == 721) {
     # And we use error status 721 to force redirects with a 302 (temporary) redirect
     # To use this, call the following from anywhere in vcl_recv: return (synth(720, "http://host/new.html"));
-    set resp.status = 302;
     set resp.http.Location = resp.reason;
+    set resp.status = 302;
     return (deliver);
   }
 


### PR DESCRIPTION
Location should be set before setting status, since status overwrites reason to ensure the presence of a reason. This behaviour changed on 4.0.2 - ASAIR your current example was working fine on 4.0.1.

I've spent 3h searching for solution so please fix this example to save time of others like me ;-)