### PR TITLE
Remove X-Forwarded-For

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -62,14 +62,6 @@ sub vcl_recv {
 
   set req.backend_hint = vdir.backend(); # send all traffic to the vdir director
 
-  if (req.restarts == 0) {
-    if (req.http.X-Forwarded-For) { # set or append the client.ip to X-Forwarded-For header
-      set req.http.X-Forwarded-For = req.http.X-Forwarded-For + ", " + client.ip;
-    } else {
-      set req.http.X-Forwarded-For = client.ip;
-    }
-  }
-
   # Normalize the header, remove the port (in case you're testing this on various TCP ports)
   set req.http.Host = regsub(req.http.Host, ":[0-9]+", "");
 


### PR DESCRIPTION
As per #8 this causes duplication of the header currently and is best removed.

With the code:
````
-   ReqHeader      X-Forwarded-For: 127.0.0.1
-   VCL_call       RECV
-   ReqUnset       X-Forwarded-For: 127.0.0.1
-   ReqHeader      X-Forwarded-For: 127.0.0.1, 127.0.0.1
````

Without it:
````
-   ReqHeader      X-Forwarded-For: 127.0.0.1
-   VCL_call       RECV
````