### PR TITLE
Improve lists of static files

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -164,7 +164,7 @@ sub vcl_recv {
   # Large static files are delivered directly to the end-user without
   # waiting for Varnish to fully read the file first.
   # Varnish 4 fully supports Streaming, so set do_stream in vcl_backend_response()
-  if (req.url ~ "^[^?]*\.(mp[34]|rar|tar|tgz|gz|wav|zip|bz2|xz|7z|avi|mov|ogm|mpe?g|mk[av]|webm)(\?.*)?$") {
+  if (req.url ~ "^[^?]*\.(7z|avi|bz2|flac|flv|gz|mka|mkv|mov|mp3|mp4|mpeg|mpg|ogg|ogm|opus|rar|tar|tgz|tbz|txz|wav|webm|xz|zip)(\?.*)?$") {
     unset req.http.Cookie;
     return (hash);
   }
@@ -173,7 +173,7 @@ sub vcl_recv {
   # A valid discussion could be held on this line: do you really need to cache static files that don't cause load? Only if you have memory left.
   # Sure, there's disk I/O, but chances are your OS will already have these files in their buffers (thus memory).
   # Before you blindly enable this, have a read here: https://ma.ttias.be/stop-caching-static-files/
-  if (req.url ~ "^[^?]*\.(bmp|bz2|css|doc|eot|flv|gif|gz|ico|jpeg|jpg|js|less|pdf|png|rtf|swf|txt|woff|xml)(\?.*)?$") {
+  if (req.url ~ "^[^?]*\.(7z|avi|bmp|bz2|css|csv|doc|docx|eot|flac|flv|gif|gz|ico|jpeg|jpg|js|less|mka|mkv|mov|mp3|mp4|mpeg|mpg|odt|otf|ogg|ogm|opus|pdf|png|ppt|pptx|rar|rtf|svg|svgz|swf|tar|tbz|tgz|ttf|txt|txz|wav|webm|webp|woff|woff2|xls|xlsx|xml|xz|zip)(\?.*)?$") {
     unset req.http.Cookie;
     return (hash);
   }
@@ -304,14 +304,14 @@ sub vcl_backend_response {
   # Enable cache for all static files
   # The same argument as the static caches from above: monitor your cache size, if you get data nuked out of it, consider giving up the static file cache.
   # Before you blindly enable this, have a read here: https://ma.ttias.be/stop-caching-static-files/
-  if (bereq.url ~ "^[^?]*\.(bmp|bz2|css|doc|eot|flv|gif|gz|ico|jpeg|jpg|js|less|mp[34]|pdf|png|rar|rtf|swf|tar|tgz|txt|wav|woff|xml|zip|webm)(\?.*)?$") {
+  if (bereq.url ~ "^[^?]*\.(7z|avi|bmp|bz2|css|csv|doc|docx|eot|flac|flv|gif|gz|ico|jpeg|jpg|js|less|mka|mkv|mov|mp3|mp4|mpeg|mpg|odt|otf|ogg|ogm|opus|pdf|png|ppt|pptx|rar|rtf|svg|svgz|swf|tar|tbz|tgz|ttf|txt|txz|wav|webm|webp|woff|woff2|xls|xlsx|xml|xz|zip)(\?.*)?$") {
     unset beresp.http.set-cookie;
   }
 
   # Large static files are delivered directly to the end-user without
   # waiting for Varnish to fully read the file first.
   # Varnish 4 fully supports Streaming, so use streaming here to avoid locking.
-  if (bereq.url ~ "^[^?]*\.(mp[34]|rar|tar|tgz|gz|wav|zip|bz2|xz|7z|avi|mov|ogm|mpe?g|mk[av]|webm)(\?.*)?$") {
+  if (bereq.url ~ "^[^?]*\.(7z|avi|bz2|flac|flv|gz|mka|mkv|mov|mp3|mp4|mpeg|mpg|ogg|ogm|opus|rar|tar|tgz|tbz|txz|wav|webm|xz|zip)(\?.*)?$") {
     unset beresp.http.set-cookie;
     set beresp.do_stream = true;  # Check memory usage it'll grow in fetch_chunksize blocks (128k by default) if the backend doesn't send a Content-Length header, so only enable it for big objects
     set beresp.do_gzip = false;   # Don't try to compress it for storage


### PR DESCRIPTION
I've improved the lists of extensions of static files:

 - Sorted file extensions alphabetically

 - Removed expressions to increase readability

 - Included all large static file extensions to the list of static files. I think it makes sense to have them in both lists so the rules can be enabled independently. The following extensions were copied to the list of static files:
  7z
  avi
  mka
  mkv
  mpg
  mpeg
  xz

 - The following extension was copied to the list of large static files:
  flv

 - Added more extensions. I think it's fair to add the following:

fonts to the static files list:
 * otf (OpenType)
 * ttf (OpenType, TrueType)
 * woff2 (Web Open Font Format v2)

images to the static files list:
 * svg (Scalable Vector Graphics, can also be fonts)
 * svgz (Scalable Vector Graphics, compressed)
 * webp (WebP image format)

documents to the static files list:
 * csv (comma-separated values)
 * docx (MS Word - Office Open XML)
 * odt (OpenDocument)
 * ppt (MS PowerPoint)
 * pptx (MS PowerPoint - Office Open XML)
 * xls (MS Excel)
 * xlsx (MS Excel - Office Open XML)

others to the static files list:
 * torrent (Bittorrent)

media to both lists:
 * ogg (Xiph's open container)
 * opus (lossy audio codec)
 * flac (lossless audio codec)

archives to both lists:
 * tbz (equivalent to tar.bz2)
 * txz (equivalent to tar.xz)