### PR TITLE
Prevent CGI proxy hack

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -65,6 +65,9 @@ sub vcl_recv {
 
   # Normalize the header, remove the port (in case you're testing this on various TCP ports)
   set req.http.Host = regsub(req.http.Host, ":[0-9]+", "");
+  
+  # Remove the proxy header (see https://httpoxy.org/#mitigate-varnish)
+  unset req.http.proxy;
 
   # Normalize the query arguments
   set req.url = std.querysort(req.url);


### PR DESCRIPTION
Moving @steffann patch upstream. This was brought up [here](https://github.com/carlalexander/debops-wordpress/pull/86). This isn't a config for only CGI applications. That said, it might useful to have it anyways. I leave it to your discretion.

>A new security advisory has been released. Abstract:

>httpoxy is a set of vulnerabilities that affect application code running in CGI, or CGI-like environments. It comes down to a simple namespace conflict:
>- RFC 3875 (CGI) puts the HTTP Proxy header from a request into the environment variables as HTTP_PROXY
>- HTTP_PROXY is a popular environment variable used to configure an outgoing proxy

>This leads to a remotely exploitable vulnerability. If you’re running PHP or CGI, you should block the Proxy header now.

>See https://httpoxy.org/#mitigate-varnish for the details.