### PR TITLE
Custom error page

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -278,8 +278,9 @@ sub vcl_hit {
       #set req.http.grace = "full";
       return (deliver);
     } else {
-      # no graced object.
-      return (fetch);
+      # no graced object and the backend is still not healthy so lets prompt users with a custom error page.
+      # In this example we use a very simple error page, please create something better :).
+      return(synth(503, "We are experiencing an internal error, please contact the sysadmin. "));
     }
   }
 


### PR DESCRIPTION
When the backend is not healthy we jump into this else condition. The first thing Varnish will do is deliver us stale content, but when we pass the grace time, users will see an error page. I think it is better to configure a custom error page (with customized text) then the default error page, which is in imho ugly.