### PR TITLE
Put 50x abandon above catchall 2min cache

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -330,16 +330,16 @@ sub vcl_backend_response {
     set beresp.http.Location = regsub(beresp.http.Location, ":[0-9]+", "");
   }
 
+  # Don't cache 50x responses
+  if (beresp.status == 500 || beresp.status == 502 || beresp.status == 503 || beresp.status == 504) {
+    return (abandon);
+  }
+
   # Set 2min cache if unset for static files
   if (beresp.ttl <= 0s || beresp.http.Set-Cookie || beresp.http.Vary == "*") {
     set beresp.ttl = 120s; # Important, you shouldn't rely on this, SET YOUR HEADERS in the backend
     set beresp.uncacheable = true;
     return (deliver);
-  }
-
-  # Don't cache 50x responses
-  if (beresp.status == 500 || beresp.status == 502 || beresp.status == 503 || beresp.status == 504) {
-    return (abandon);
   }
 
   # Allow stale content, in case the backend goes down.


### PR DESCRIPTION
In my testing, errors were caught/TTL set before the abandon (#24 )

```
--  BerespProtocol HTTP/1.1
--  BerespStatus   504
--  BerespReason   Gateway Time-out
--  BerespHeader   Server: nginx
--  BerespHeader   Date: Sun, 17 Sep 2017 17:39:12 GMT
--  BerespHeader   Content-Type: text/html; charset=utf-8
--  BerespHeader   Content-Length: 578
--  BerespHeader   Connection: keep-alive
--  TTL            RFC -1 10 -1 1505669952 1505669952 1505669952 0 0
--  VCL_call       BACKEND_RESPONSE
--  TTL            VCL 120 10 0 1505669952
--  VCL_return     deliver
--  Storage        malloc s0
```