### PR TITLE
Add fbclid to the list of parameters to be removed from URLs

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -107,12 +107,10 @@ sub vcl_recv {
   }
 
   # Some generic URL manipulation, useful for all templates that follow
-  # First remove the Google Analytics added parameters, useless for our backend
-  if (req.url ~ "(\?|&)(utm_source|utm_medium|utm_campaign|utm_content|gclid|cx|ie|cof|siteurl)=") {
-    set req.url = regsuball(req.url, "&(utm_source|utm_medium|utm_campaign|utm_content|gclid|cx|ie|cof|siteurl)=([A-z0-9_\-\.%25]+)", "");
-    set req.url = regsuball(req.url, "\?(utm_source|utm_medium|utm_campaign|utm_content|gclid|cx|ie|cof|siteurl)=([A-z0-9_\-\.%25]+)", "?");
-    set req.url = regsub(req.url, "\?&", "?");
-    set req.url = regsub(req.url, "\?$", "");
+  # First remove URL parameters used to track effectiveness of online marketing campaigns
+  if (req.url ~ "(\?|&)(utm_[a-z]+|gclid|cx|ie|cof|siteurl)=") {
+      set req.url = regsuball(req.url, "(utm_[a-z]+|gclid|cx|ie|cof|siteurl)=[-_A-z0-9+()%.]+&?", "");
+      set req.url = regsub(req.url, "[?|&]+$", "");
   }
 
   # Strip hash, server doesn't need it.

--- a/default.vcl
+++ b/default.vcl
@@ -108,8 +108,8 @@ sub vcl_recv {
 
   # Some generic URL manipulation, useful for all templates that follow
   # First remove URL parameters used to track effectiveness of online marketing campaigns
-  if (req.url ~ "(\?|&)(utm_[a-z]+|gclid|cx|ie|cof|siteurl)=") {
-      set req.url = regsuball(req.url, "(utm_[a-z]+|gclid|cx|ie|cof|siteurl)=[-_A-z0-9+()%.]+&?", "");
+  if (req.url ~ "(\?|&)(utm_[a-z]+|gclid|cx|ie|cof|siteurl|fbclid)=") {
+      set req.url = regsuball(req.url, "(utm_[a-z]+|gclid|cx|ie|cof|siteurl|fbclid)=[-_A-z0-9+()%.]+&?", "");
       set req.url = regsub(req.url, "[?|&]+$", "");
   }
 


### PR DESCRIPTION
Facebook was destroying our cache before this.

The refactor speeds up processing as now we clean up the mess in just 2 steps instead of 4.